### PR TITLE
fix: 添加 setuptools 依赖解决 gunicorn 启动报错

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask-Migrate==4.0.4
 Flask-Cors==3.0.10
 flask-restx==1.1.0
 gunicorn==20.1.0
+setuptools>=70.0.0
 matplotlib
 networkx
 paramiko


### PR DESCRIPTION
## Summary
- 在 `requirements.txt` 中显式添加 `setuptools>=70.0.0` 依赖
- 修复因 `python:3.12-slim` 基础镜像更新后不再预装 `setuptools`，导致 `gunicorn==20.1.0` 启动时 `ModuleNotFoundError: No module named 'pkg_resources'` 的问题

## Root Cause
`python:3.12-slim` Docker 镜像在近期更新中移除了预装的 `setuptools`，而 `gunicorn==20.1.0` 的入口脚本依赖 `pkg_resources`（属于 `setuptools`），因此容器启动失败。

## Test Plan
- [ ] CI/CD 流水线构建通过
- [ ] 生产环境容器正常启动，gunicorn 无报错


Made with [Cursor](https://cursor.com)