### PR TITLE
fix: 移除 Dockerfile 中的清华镜像源

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-c
 
 # 安装Python依赖
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip install --no-cache-dir -r requirements.txt
 
 # 复制项目文件
 COPY . .


### PR DESCRIPTION
## Summary
- 移除 Dockerfile 中 pip install 的 `-i https://pypi.tuna.tsinghua.edu.cn/simple` 参数
- CI 构建在 GitHub Actions 海外机器执行，清华镜像源返回 HTTP 403 导致构建失败

## Test Plan
- [ ] CI/CD 流水线 pip install 步骤通过
- [ ] 生产环境容器正常启动


Made with [Cursor](https://cursor.com)