### PR TITLE
fix: 升级 gunicorn 至 23.0.0 解决 pkg_resources 缺失

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ Flask-SQLAlchemy==3.0.3
 Flask-Migrate==4.0.4
 Flask-Cors==3.0.10
 flask-restx==1.1.0
-gunicorn==20.1.0
-setuptools>=70.0.0
+gunicorn==23.0.0
 matplotlib
 networkx
 paramiko


### PR DESCRIPTION
## Summary
- 将 `gunicorn` 从 `20.1.0` 升级到 `23.0.0`
- 移除不再需要的 `setuptools` 显式依赖

## Root Cause
`setuptools>=82` 已将 `pkg_resources` 从核心包中移除。`gunicorn==20.1.0` 在 `util.py` 中 `import pkg_resources`，导致容器启动失败。`gunicorn>=22` 改用 `importlib.metadata`，不再依赖 `pkg_resources`。

## Test Plan
- [ ] CI/CD 流水线通过
- [ ] 生产环境容器正常启动，gunicorn 无报错


Made with [Cursor](https://cursor.com)