### PR TITLE
[codex] use sha tag for backend deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -77,7 +77,8 @@ jobs:
     steps:
       - name: Trigger deploy webhook
         run: |
+          SHORT_SHA=${GITHUB_SHA::7}
           curl -sf -X POST "${{ secrets.DEPLOY_WEBHOOK_URL }}" \
             -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d '{"service":"backend","image":"${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:latest"}'
+            -d "{\"service\":\"backend\",\"image\":\"${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:${SHORT_SHA}\"}"


### PR DESCRIPTION
## Summary
- deploy backend using the commit short SHA image tag instead of `latest`
- keep publishing both `latest` and short SHA tags for compatibility

## Why
The deploy server can receive stale `latest` images from Docker Hub/mirrors. Sending the short SHA image to the webhook makes each deployment point to the exact CI artifact.

## Validation
- Parsed `.github/workflows/ci-cd.yml` as YAML
- Pushed branch `codex/deploy-backend-sha-tag`
