### PR TITLE
Add user action audit API

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,7 +22,9 @@ def create_app(config_name):
     console_handler.setLevel(logging.DEBUG)
 
     # 设置日志格式
-    formatter = logging.Formatter("[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
+    formatter = logging.Formatter(
+        "[%(asctime)s] %(levelname)s in %(module)s: %(message)s"
+    )
     console_handler.setFormatter(formatter)
 
     # 添加处理器到应用日志器
@@ -44,6 +46,12 @@ def create_app(config_name):
 
     db.init_app(app)
     migrate.init_app(app, db)
+
+    # 注册审计钩子：仅记录已认证 API 请求的元数据
+    from app.services.audit_service import audit_service
+
+    app.before_request(audit_service.attach_request_user)
+    app.after_request(audit_service.log_request)
 
     # 初始化COS工具
     from app.utils.cos_utils import cos_utils

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -7,6 +7,7 @@ from flask import Blueprint
 from flask_cors import CORS
 from flask_restx import Api
 
+from app.api.namespaces.audit_ns import api as audit_ns
 from app.api.namespaces.auth_ns import api as auth_ns
 from app.api.namespaces.dataset_ns import api as dataset_ns
 from app.api.namespaces.dictionary_ns import api as dictionary_ns
@@ -37,3 +38,4 @@ api.add_namespace(service_ns)
 api.add_namespace(auth_ns, path="/auth")  # 添加认证命名空间
 api.add_namespace(dictionary_ns, path="/dictionaries")
 api.add_namespace(dataset_ns, path="/datasets")  # 添加数据集命名空间
+api.add_namespace(audit_ns, path="/audit")  # 添加审计命名空间

--- a/app/api/namespaces/audit_ns.py
+++ b/app/api/namespaces/audit_ns.py
@@ -1,0 +1,90 @@
+"""
+用户行为审计API
+"""
+
+from flask import g, request
+from flask_restx import Namespace, Resource, fields
+
+from app.services.audit_service import audit_service
+
+api = Namespace("audit", description="用户行为审计API")
+
+action_log_model = api.model(
+    "UserActionLog",
+    {
+        "id": fields.String(description="日志ID"),
+        "userId": fields.String(description="用户ID"),
+        "username": fields.String(description="用户名"),
+        "name": fields.String(description="用户姓名"),
+        "roleId": fields.String(description="角色ID"),
+        "actionType": fields.String(description="行为类型"),
+        "method": fields.String(description="HTTP方法"),
+        "path": fields.String(description="请求路径"),
+        "endpoint": fields.String(description="Flask endpoint"),
+        "statusCode": fields.Integer(description="响应状态码"),
+        "clientIp": fields.String(description="客户端IP"),
+        "userAgent": fields.String(description="User-Agent"),
+        "createdAt": fields.Integer(description="创建时间戳"),
+    },
+)
+
+pagination_model = api.model(
+    "AuditPagination",
+    {
+        "total": fields.Integer(description="总条数"),
+        "page": fields.Integer(description="当前页"),
+        "pageSize": fields.Integer(description="每页条数"),
+    },
+)
+
+action_logs_response = api.model(
+    "ActionLogsResponse",
+    {
+        "status": fields.String(description="响应状态"),
+        "logs": fields.List(
+            fields.Nested(action_log_model), description="行为日志列表"
+        ),
+        "pagination": fields.Nested(pagination_model, description="分页信息"),
+    },
+)
+
+
+@api.route("/action-logs")
+class ActionLogs(Resource):
+    @api.doc(
+        "list_action_logs",
+        params={
+            "userId": "用户ID",
+            "username": "用户名",
+            "actionType": "行为类型",
+            "page": "页码，默认1",
+            "pageSize": "每页条数，默认20，最大100",
+        },
+    )
+    @api.marshal_with(action_logs_response, code=200)
+    @api.response(401, "Unauthorized")
+    @api.response(403, "Forbidden")
+    def get(self):
+        """管理员查询用户行为日志"""
+        user = getattr(g, "audit_user", None)
+        if not user:
+            return {
+                "status": "error",
+                "logs": [],
+                "pagination": {"total": 0, "page": 1, "pageSize": 20},
+            }, 401
+        if not audit_service.has_admin_permission(user):
+            return {
+                "status": "error",
+                "logs": [],
+                "pagination": {"total": 0, "page": 1, "pageSize": 20},
+            }, 403
+
+        result = audit_service.list_action_logs(
+            user_id=request.args.get("userId"),
+            username=request.args.get("username"),
+            action_type=request.args.get("actionType"),
+            page=request.args.get("page", 1),
+            page_size=request.args.get("pageSize", 20),
+        )
+        return {"status": "success", **result}, 200

--- a/app/api/namespaces/auth_ns.py
+++ b/app/api/namespaces/auth_ns.py
@@ -16,6 +16,7 @@ from app.models.user.role import Role
 from app.models.user.role_permission import RolePermission
 from app.models.user.user import User
 from app.models.user.user_tokens import UserToken
+from app.services.audit_service import audit_service
 from app.utils.password_utils import verify_password, hash_password
 
 # 创建命名空间
@@ -178,6 +179,16 @@ class Login(Resource):
             db.session.add(user_token)
 
         db.session.commit()
+        audit_service.log_action(
+            user=user,
+            action_type="auth.login",
+            method=request.method,
+            path=request.path,
+            endpoint=request.endpoint,
+            status_code=200,
+            client_ip=audit_service.get_client_ip(),
+            user_agent=request.headers.get("User-Agent", ""),
+        )
 
         # 构建响应
         response = {
@@ -372,6 +383,16 @@ class Register(Resource):
         db.session.add(user_token)
 
         db.session.commit()
+        audit_service.log_action(
+            user=user,
+            action_type="auth.register",
+            method=request.method,
+            path=request.path,
+            endpoint=request.endpoint,
+            status_code=200,
+            client_ip=audit_service.get_client_ip(),
+            user_agent=request.headers.get("User-Agent", ""),
+        )
 
         role = Role.query.filter_by(id=user.role_id, deleted=0).first()
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -13,6 +13,7 @@ from app.models.service.service_norm import ServiceNorm
 from app.models.service.service_source import ServiceSource
 from app.models.user.role import Role
 from app.models.user.role_permission import RolePermission
+from app.models.user_action_log import UserActionLog
 
 # 导入所有模型，使它们可以通过app.models直接访问
 from app.models.user.user import User
@@ -27,6 +28,7 @@ __all__ = [
     "Role",
     "RolePermission",
     "UserToken",
+    "UserActionLog",
     "Service",
     "ServiceNorm",
     "ServiceSource",

--- a/app/models/user_action_log.py
+++ b/app/models/user_action_log.py
@@ -1,0 +1,80 @@
+"""
+用户行为审计日志模型
+记录已认证 API 请求的元数据，不保存请求体或敏感字段。
+"""
+
+import datetime
+import uuid
+
+from app.extensions import db
+
+
+class UserActionLog(db.Model):
+    """用户行为审计日志"""
+
+    __tablename__ = "user_action_logs"
+
+    id = db.Column(db.String(36), primary_key=True, comment="日志ID")
+    user_id = db.Column(
+        db.String(36),
+        db.ForeignKey("users.id"),
+        nullable=True,
+        index=True,
+        comment="用户ID",
+    )
+    username = db.Column(
+        db.String(100), nullable=True, index=True, comment="用户名"
+    )  # noqa: E501
+    name = db.Column(db.String(100), nullable=True, comment="用户姓名")
+    role_id = db.Column(
+        db.String(36), nullable=True, index=True, comment="角色ID"
+    )  # noqa: E501
+
+    action_type = db.Column(
+        db.String(100), nullable=False, index=True, comment="行为类型"
+    )
+    method = db.Column(db.String(10), nullable=False, comment="HTTP方法")
+    path = db.Column(
+        db.String(255), nullable=False, index=True, comment="请求路径"
+    )  # noqa: E501
+    endpoint = db.Column(
+        db.String(255), nullable=True, comment="Flask endpoint"
+    )  # noqa: E501
+    status_code = db.Column(
+        db.Integer, nullable=False, index=True, comment="响应状态码"
+    )
+    client_ip = db.Column(
+        db.String(64), nullable=True, index=True, comment="客户端IP"
+    )  # noqa: E501
+    user_agent = db.Column(db.String(512), nullable=True, comment="User-Agent")
+    created_at = db.Column(
+        db.BigInteger, nullable=False, index=True, comment="创建时间戳"
+    )
+
+    user = db.relationship(
+        "User", backref=db.backref("action_logs", lazy=True)
+    )  # noqa: E501
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if not self.id:
+            self.id = str(uuid.uuid4())
+        if not self.created_at:
+            self.created_at = int(datetime.datetime.now().timestamp() * 1000)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "userId": self.user_id,
+            "username": self.username,
+            "name": self.name,
+            "roleId": self.role_id,
+            "actionType": self.action_type,
+            "method": self.method,
+            "path": self.path,
+            "endpoint": self.endpoint,
+            "statusCode": self.status_code,
+            "clientIp": self.client_ip,
+            "userAgent": self.user_agent,
+            "createdAt": self.created_at,
+        }

--- a/app/services/audit_service.py
+++ b/app/services/audit_service.py
@@ -1,0 +1,236 @@
+"""
+用户行为审计服务
+提供认证用户解析、请求自动记录和管理员查询能力。
+"""
+
+import datetime
+from typing import Optional
+
+from flask import current_app, g, request
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.extensions import db
+from app.models.user.role_permission import RolePermission
+from app.models.user.user import User
+from app.models.user.user_tokens import UserToken
+from app.models.user_action_log import UserActionLog
+
+
+class AuditService:
+    """审计日志服务"""
+
+    SKIP_PATH_PREFIXES = (
+        "/api/docs",
+        "/api/swagger",
+        "/swagger",
+        "/static",
+    )
+    SKIP_PATHS = {
+        "/api/health",
+        "/api/audit/action-logs",
+    }
+
+    def __init__(self):
+        self._table_checked = False
+
+    def ensure_table(self):
+        """在没有迁移目录的部署环境中按需创建审计表。"""
+        if self._table_checked:
+            return
+        try:
+            UserActionLog.__table__.create(db.engine, checkfirst=True)
+            self._table_checked = True
+        except SQLAlchemyError as exc:
+            db.session.rollback()
+            current_app.logger.warning("审计日志表检查/创建失败: %s", exc)
+
+    def get_user_from_token(self, token: str) -> Optional[User]:
+        if not token:
+            return None
+
+        user_token = UserToken.query.filter_by(token=token).first()
+        if not user_token:
+            return None
+
+        now = int(datetime.datetime.now().timestamp() * 1000)
+        if user_token.expires_at < now:
+            return None
+
+        user = User.query.filter_by(id=user_token.user_id, deleted=0).first()
+        if not user or user.status != 1:
+            return None
+
+        return user
+
+    def attach_request_user(self):
+        """在请求进入业务处理前解析用户，避免登出时 token 被删除后丢失用户信息。"""
+        token = request.headers.get("Access-Token", "")
+        g.audit_user = self.get_user_from_token(token)
+
+    def has_admin_permission(self, user: Optional[User]) -> bool:
+        if not user:
+            return False
+        if user.role_id in ("admin", "root"):
+            return True
+        return (
+            RolePermission.query.filter_by(
+                role_id=user.role_id,
+                permission_id="admin",
+            ).first()
+            is not None
+        )
+
+    def should_log_request(self) -> bool:
+        if request.method == "OPTIONS":
+            return False
+        path = request.path or ""
+        if path in self.SKIP_PATHS:
+            return False
+        return path.startswith("/api/") and not any(
+            path.startswith(prefix) for prefix in self.SKIP_PATH_PREFIXES
+        )
+
+    def infer_action_type(self) -> str:
+        method = request.method.upper()
+        path = request.path or ""
+
+        if path == "/api/auth/login" and method == "POST":
+            return "auth.login"
+        if path == "/api/auth/logout" and method == "POST":
+            return "auth.logout"
+        if path == "/api/auth/info" and method == "GET":
+            return "auth.info"
+        if path == "/api/auth/register" and method == "POST":
+            return "auth.register"
+
+        if path == "/api/users":
+            return "users.create" if method == "POST" else "users.list"
+        if path.startswith("/api/users/"):
+            if path.endswith("/update"):
+                return "users.update"
+            if path.endswith("/delete"):
+                return "users.delete"
+            if path.endswith("/status"):
+                return "users.status"
+            if path.endswith("/password"):
+                return "users.password"
+            if path.endswith("/role"):
+                return "users.role"
+            return "users.detail"
+
+        if path.startswith("/api/services/"):
+            if path.endswith("/deploy"):
+                return "services.deploy"
+            if path.endswith("/stop"):
+                return "services.stop"
+            if path.endswith("/delete"):
+                return "services.delete"
+            if path.endswith("/publish"):
+                return "services.publish"
+            return "services.request"
+
+        if path.startswith("/api/datasets"):
+            return "datasets.request"
+        if path.startswith("/api/dictionaries"):
+            return "dictionaries.request"
+        if path.startswith("/api/audit"):
+            return "audit.request"
+        return "api.request"
+
+    def get_client_ip(self) -> str:
+        forwarded_for = request.headers.get("X-Forwarded-For", "")
+        if forwarded_for:
+            return forwarded_for.split(",")[0].strip()
+        return request.headers.get("X-Real-IP") or request.remote_addr or ""
+
+    def log_request(self, response):
+        if not self.should_log_request():
+            return response
+
+        user = getattr(g, "audit_user", None)
+        if not user:
+            return response
+
+        self.log_action(
+            user=user,
+            action_type=self.infer_action_type(),
+            method=request.method,
+            path=request.path,
+            endpoint=request.endpoint,
+            status_code=response.status_code,
+            client_ip=self.get_client_ip(),
+            user_agent=(request.headers.get("User-Agent") or "")[:512],
+        )
+        return response
+
+    def log_action(
+        self,
+        user: User,
+        action_type: str,
+        method: str,
+        path: str,
+        endpoint: str,
+        status_code: int,
+        client_ip: str,
+        user_agent: str,
+    ):
+        try:
+            self.ensure_table()
+            log = UserActionLog(
+                user_id=user.id,
+                username=user.username,
+                name=user.name,
+                role_id=user.role_id,
+                action_type=action_type,
+                method=method.upper(),
+                path=path[:255],
+                endpoint=(endpoint or "")[:255],
+                status_code=status_code,
+                client_ip=(client_ip or "")[:64],
+                user_agent=(user_agent or "")[:512],
+            )
+            db.session.add(log)
+            db.session.commit()
+        except Exception as exc:
+            db.session.rollback()
+            current_app.logger.warning("记录用户行为日志失败: %s", exc)
+
+    def list_action_logs(
+        self,
+        user_id: str = None,
+        username: str = None,
+        action_type: str = None,
+        page: int = 1,
+        page_size: int = 20,
+    ):
+        self.ensure_table()
+        page = max(int(page or 1), 1)
+        page_size = min(max(int(page_size or 20), 1), 100)
+
+        query = UserActionLog.query
+        if user_id:
+            query = query.filter(UserActionLog.user_id == user_id)
+        if username:
+            query = query.filter(UserActionLog.username == username)
+        if action_type:
+            query = query.filter(UserActionLog.action_type == action_type)
+
+        total = query.count()
+        logs = (
+            query.order_by(UserActionLog.created_at.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+            .all()
+        )
+
+        return {
+            "logs": [log.to_dict() for log in logs],
+            "pagination": {
+                "total": total,
+                "page": page,
+                "pageSize": page_size,
+            },
+        }
+
+
+audit_service = AuditService()

--- a/tests/integration/test_audit_api.py
+++ b/tests/integration/test_audit_api.py
@@ -1,0 +1,130 @@
+import datetime
+import json
+
+import pytest
+
+from app import create_app
+from app.extensions import db
+from app.models import Role, RolePermission, User, UserActionLog, UserToken
+
+
+@pytest.fixture
+def client():
+    app = create_app("testing")
+
+    with app.test_client() as client:
+        with app.app_context():
+            db.create_all()
+            seed_users()
+            yield client
+            db.session.remove()
+            db.drop_all()
+
+
+def seed_users():
+    now = int(datetime.datetime.now().timestamp() * 1000)
+    expires_at = now + 7 * 24 * 60 * 60 * 1000
+
+    admin = User(
+        id="admin-user-id",
+        username="admin",
+        name="管理员",
+        password="x",
+        role_id="admin",
+        status=1,
+        deleted=0,
+        create_time=now,
+    )
+    user = User(
+        id="normal-user-id",
+        username="normal",
+        name="普通用户",
+        password="x",
+        role_id="user",
+        status=1,
+        deleted=0,
+        create_time=now,
+    )
+    admin_role = Role(
+        id="admin",
+        name="管理员",
+        describe="拥有管理员权限",
+        status=1,
+        deleted=0,
+        create_time=now,
+    )
+    user_role = Role(
+        id="user",
+        name="用户",
+        describe="拥有用户权限",
+        status=1,
+        deleted=0,
+        create_time=now,
+    )
+    admin_permission = RolePermission(
+        id=1,
+        role_id="admin",
+        permission_id="admin",
+        permission_name="管理员",
+    )
+    db.session.add_all(
+        [
+            admin,
+            user,
+            admin_role,
+            user_role,
+            admin_permission,
+            UserToken(
+                user_id=admin.id, token="admin-token", expires_at=expires_at
+            ),  # noqa: E501
+            UserToken(
+                user_id=user.id, token="user-token", expires_at=expires_at
+            ),  # noqa: E501
+        ]
+    )
+    db.session.commit()
+
+
+def test_authenticated_api_request_is_logged_and_admin_can_query(client):
+    response = client.get("/api/users", headers={"Access-Token": "user-token"})
+    assert response.status_code == 200
+
+    query = client.get(
+        "/api/audit/action-logs?userId=normal-user-id",
+        headers={"Access-Token": "admin-token"},
+    )
+    assert query.status_code == 200
+
+    data = json.loads(query.data)
+    assert data["status"] == "success"
+    assert data["pagination"]["total"] == 1
+    assert data["logs"][0]["userId"] == "normal-user-id"
+    assert data["logs"][0]["username"] == "normal"
+    assert data["logs"][0]["actionType"] == "users.list"
+    assert data["logs"][0]["method"] == "GET"
+    assert data["logs"][0]["path"] == "/api/users"
+    assert data["logs"][0]["statusCode"] == 200
+
+
+def test_non_admin_cannot_query_action_logs(client):
+    log = UserActionLog(
+        user_id="normal-user-id",
+        username="normal",
+        name="普通用户",
+        role_id="user",
+        action_type="users.list",
+        method="GET",
+        path="/api/users",
+        endpoint="users_user_list",
+        status_code=200,
+        client_ip="127.0.0.1",
+        user_agent="pytest",
+    )
+    db.session.add(log)
+    db.session.commit()
+
+    response = client.get(
+        "/api/audit/action-logs?userId=normal-user-id",
+        headers={"Access-Token": "user-token"},
+    )
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Add a metadata-only user action audit log model.
- Resolve authenticated users before request handlers and record authenticated API requests after responses.
- Record successful login/register events explicitly because those requests do not carry an Access-Token yet.
- Add admin-only `GET /api/audit/action-logs` with user/action filters and pagination.
- Create the audit table on demand with `checkfirst=True` because this repo currently has Flask-Migrate support but no committed migrations directory.

## Scope
- Backend API foundation for user behavior monitoring.
- Does not log request bodies, passwords, or payload data.
- Frontend display is tracked separately in fdueblab/ioeb#107.

## Validation
- PASS: `./venv/bin/python -m pytest tests/integration/test_audit_api.py tests/integration/test_api.py`
- PASS: `./venv/bin/python -m black --check app/models/user_action_log.py app/services/audit_service.py app/api/namespaces/audit_ns.py tests/integration/test_audit_api.py app/__init__.py app/api/__init__.py app/models/__init__.py`
- PASS: `./venv/bin/python -m flake8 app/models/user_action_log.py app/services/audit_service.py app/api/namespaces/audit_ns.py tests/integration/test_audit_api.py app/__init__.py app/api/__init__.py app/models/__init__.py`
- PASS: `./venv/bin/python -m py_compile app/api/namespaces/auth_ns.py app/models/user_action_log.py app/services/audit_service.py app/api/namespaces/audit_ns.py tests/integration/test_audit_api.py app/__init__.py app/api/__init__.py app/models/__init__.py`

Note: `app/api/namespaces/auth_ns.py` has pre-existing file-level flake8/black issues; this PR only adds audit logging calls there.

Fixes #62