### PR TITLE
feat: isolate COS keys by environment

### DIFF
--- a/app/utils/cos_utils.py
+++ b/app/utils/cos_utils.py
@@ -35,6 +35,8 @@ class COSUtils:
         self._client = None
         self._bucket = None
         self._region = None
+        self._key_prefix = ""
+        self._delete_allowed_prefixes = []
         self._initialized = True
 
     def init_app(self, app):
@@ -45,6 +47,10 @@ class COSUtils:
         """
         self._region = app.config.get("COS_REGION")
         self._bucket = app.config.get("COS_BUCKET")
+        self._key_prefix = self._normalize_prefix(app.config.get("COS_KEY_PREFIX", ""))
+        self._delete_allowed_prefixes = self._parse_prefixes(
+            app.config.get("COS_DELETE_ALLOWED_PREFIXES", "")
+        )
 
         # 获取密钥
         secret_id = app.config.get("COS_SECRET_ID") or os.environ.get("COS_SECRET_ID")
@@ -68,6 +74,26 @@ class COSUtils:
         app.logger.info(
             f"COS client initialized with region: {self._region}, bucket: {self._bucket}"
         )
+
+    @staticmethod
+    def _normalize_prefix(prefix: str) -> str:
+        """Normalize a COS key prefix to either empty string or trailing slash form."""
+        normalized = (prefix or "").strip().strip("/")
+        return f"{normalized}/" if normalized else ""
+
+    @classmethod
+    def _parse_prefixes(cls, prefixes: str) -> List[str]:
+        """Parse comma-separated prefixes used to guard destructive COS operations."""
+        return [
+            normalized
+            for normalized in (cls._normalize_prefix(item) for item in (prefixes or "").split(","))
+            if normalized
+        ]
+
+    def _can_delete_key(self, cos_path: str) -> bool:
+        if not self._delete_allowed_prefixes:
+            return True
+        return any(cos_path.startswith(prefix) for prefix in self._delete_allowed_prefixes)
 
     @property
     def client(self) -> CosS3Client:
@@ -250,6 +276,10 @@ class COSUtils:
             COSError: 删除失败时抛出
         """
         try:
+            if not self._can_delete_key(cos_path):
+                logging.warning("Skip COS delete outside allowed prefixes: %s", cos_path)
+                return True
+
             # 删除文件
             self.client.delete_object(Bucket=self.bucket, Key=cos_path)
 
@@ -271,17 +301,29 @@ class COSUtils:
             COSError: 删除失败时抛出
         """
         try:
+            guarded_paths = []
+            skipped_paths = []
+            for path in cos_paths:
+                if self._can_delete_key(path):
+                    guarded_paths.append(path)
+                else:
+                    skipped_paths.append(path)
+                    logging.warning("Skip COS delete outside allowed prefixes: %s", path)
+
+            if not guarded_paths:
+                return [], skipped_paths
+
             # 批量删除文件
             response = self.client.delete_objects(
                 Bucket=self.bucket,
-                Delete={"Object": [{"Key": path} for path in cos_paths], "Quiet": "false"},
+                Delete={"Object": [{"Key": path} for path in guarded_paths], "Quiet": "false"},
             )
 
             # 处理结果
             deleted = [item.get("Key") for item in response.get("Deleted", [])]
             errors = [item.get("Key") for item in response.get("Error", [])]
 
-            return deleted, errors
+            return deleted, errors + skipped_paths
         except Exception as e:
             logging.error(f"Failed to batch delete files from COS: {str(e)}")
             raise COSError(f"Failed to batch delete files from COS: {str(e)}")
@@ -341,6 +383,7 @@ class COSUtils:
         unique_filename = f"{uuid.uuid4().hex}_{filename}"
 
         # 构建路径
+        prefix = f"{self._key_prefix}{prefix}" if self._key_prefix else prefix
         if prefix:
             # 确保前缀以/结尾
             if not prefix.endswith("/"):

--- a/config.py
+++ b/config.py
@@ -27,6 +27,8 @@ class Config:
     COS_SECRET_KEY = os.getenv("COS_SECRET_KEY", None)
     COS_REGION = os.getenv("COS_REGION", "ap-beijing")
     COS_BUCKET = os.getenv("COS_BUCKET", None)
+    COS_KEY_PREFIX = os.getenv("COS_KEY_PREFIX", "")
+    COS_DELETE_ALLOWED_PREFIXES = os.getenv("COS_DELETE_ALLOWED_PREFIXES", "")
 
     # 微信小程序配置（用于 wx.login code 换 openid）
     WX_APP_ID = os.getenv("WX_APP_ID", "wx7c397441311585b2")

--- a/tests/unit/test_cos_utils.py
+++ b/tests/unit/test_cos_utils.py
@@ -1,0 +1,50 @@
+from app.utils.cos_utils import COSUtils
+
+
+class FakeCOSClient:
+    def __init__(self):
+        self.deleted_keys = []
+
+    def delete_object(self, Bucket, Key):  # noqa: N803 - third-party SDK naming
+        self.deleted_keys.append((Bucket, Key))
+        return {}
+
+
+def test_generate_cos_path_applies_environment_prefix():
+    cos_utils = COSUtils()
+    original_prefix = cos_utils._key_prefix
+
+    try:
+        cos_utils._key_prefix = "staging/"
+
+        path = cos_utils.generate_cos_path("dataset.csv", "datasets/csv")
+
+        assert path.startswith("staging/datasets/csv/")
+        assert path.endswith("_dataset.csv")
+    finally:
+        cos_utils._key_prefix = original_prefix
+
+
+def test_delete_file_skips_keys_outside_allowed_prefixes():
+    cos_utils = COSUtils()
+    original_client = cos_utils._client
+    original_bucket = cos_utils._bucket
+    original_allowed_prefixes = cos_utils._delete_allowed_prefixes
+    fake_client = FakeCOSClient()
+
+    try:
+        cos_utils._client = fake_client
+        cos_utils._bucket = "test-bucket"
+        cos_utils._delete_allowed_prefixes = ["staging/"]
+
+        assert cos_utils.delete_file("datasets/csv/legacy.csv") is True
+        assert fake_client.deleted_keys == []
+
+        assert cos_utils.delete_file("staging/datasets/csv/new.csv") is True
+        assert fake_client.deleted_keys == [
+            ("test-bucket", "staging/datasets/csv/new.csv")
+        ]
+    finally:
+        cos_utils._client = original_client
+        cos_utils._bucket = original_bucket
+        cos_utils._delete_allowed_prefixes = original_allowed_prefixes


### PR DESCRIPTION
## Summary
- add optional COS_KEY_PREFIX so newly uploaded COS objects can be namespaced by environment
- add COS_DELETE_ALLOWED_PREFIXES guard so staging can avoid deleting legacy/shared production objects
- cover prefix generation and delete guard behavior with unit tests

## Why
Staging currently uses a copied production-like database where COS object keys may point to shared objects. Without a delete guard, staging users could delete COS files that production still references.

## Validation
- python -m py_compile config.py app/utils/cos_utils.py tests/unit/test_cos_utils.py
- pytest was not available in the local environment, so full tests are left to CI

## Deployment notes
After this backend image is deployed, set staging backend env:
- COS_KEY_PREFIX=staging
- COS_DELETE_ALLOWED_PREFIXES=staging

For production, use COS_KEY_PREFIX=prod after the scheduled production release. Keep COS_DELETE_ALLOWED_PREFIXES empty initially if production must still delete legacy unprefixed objects.