### PR TITLE
ci: split staging and production deployments

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  release:
+    types: [published]
 
 env:
   PYTHON_VERSION: "3.10"
@@ -52,7 +54,7 @@ jobs:
   build:
     name: Build & Push Image
     needs: test
-    if: github.event_name == 'push'
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,21 +66,44 @@ jobs:
 
       - name: Build and push
         run: |
-          SHORT_SHA=${GITHUB_SHA::7}
-          docker build \
-            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:latest \
-            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:${SHORT_SHA} .
-          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend --all-tags
+          if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+            IMAGE_TAG="${GITHUB_REF_NAME}"
+            docker build \
+              -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:${IMAGE_TAG} .
+            docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:${IMAGE_TAG}
+          else
+            IMAGE_TAG=${GITHUB_SHA::7}
+            docker build \
+              -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:latest \
+              -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:${IMAGE_TAG} .
+            docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:latest
+            docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:${IMAGE_TAG}
+          fi
 
-  deploy:
-    name: Deploy
+  deploy-staging:
+    name: Deploy Staging
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger deploy webhook
+      - name: Trigger staging deploy webhook
         run: |
-          SHORT_SHA=${GITHUB_SHA::7}
+          IMAGE_TAG=${GITHUB_SHA::7}
+          curl -sf -X POST "${{ secrets.STAGING_DEPLOY_WEBHOOK_URL }}" \
+            -H "X-Deploy-Token: ${{ secrets.STAGING_DEPLOY_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"service\":\"backend\",\"image\":\"${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:${IMAGE_TAG}\"}"
+
+  deploy-production:
+    name: Deploy Production
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger production deploy webhook
+        run: |
+          IMAGE_TAG="${GITHUB_REF_NAME}"
           curl -sf -X POST "${{ secrets.DEPLOY_WEBHOOK_URL }}" \
             -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{\"service\":\"backend\",\"image\":\"${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:${SHORT_SHA}\"}"
+            -d "{\"service\":\"backend\",\"image\":\"${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-backend:${IMAGE_TAG}\"}"


### PR DESCRIPTION
## Summary
- deploy main pushes to the staging webhook secrets
- deploy production only from published GitHub releases
- tag production images with the release tag instead of a commit SHA

## Release model
Main pushes keep building latest and short-SHA images for staging. Production releases build an image tagged with the GitHub Release tag and trigger the existing production webhook.

## Validation
- Ruby YAML parsing for the modified workflow file passed
- actionlint is not installed locally, so GitHub Actions rule lint was not run