### PR TITLE
feat: filter 分页与精简列表，新增 mcp-options 和 smart-search

### DIFF
--- a/app/api/namespaces/service_ns.py
+++ b/app/api/namespaces/service_ns.py
@@ -168,6 +168,84 @@ services_response = api.model(
     }
 )
 
+service_list_api_brief = api.model(
+    "ServiceListApiBrief",
+    {
+        "responseFileName": fields.String(description="响应文件名(想定式生成算法)"),
+    },
+)
+
+service_list_item_model = api.model(
+    "ServiceListItem",
+    {
+        "id": fields.String(description="服务ID"),
+        "name": fields.String(description="服务名称"),
+        "attribute": fields.String(description="服务属性"),
+        "type": fields.String(description="服务类型"),
+        "domain": fields.String(description="领域"),
+        "industry": fields.String(description="行业"),
+        "scenario": fields.String(description="场景"),
+        "technology": fields.String(description="技术"),
+        "network": fields.String(description="网络类型"),
+        "port": fields.String(description="端口映射"),
+        "volume": fields.String(description="数据卷映射"),
+        "status": fields.String(description="服务状态"),
+        "number": fields.Integer(description="服务调用次数"),
+        "deleted": fields.Integer(description="是否删除"),
+        "createTime": fields.Integer(description="创建时间"),
+        "creatorId": fields.String(description="创建者ID"),
+        "norm": fields.List(fields.Nested(norm_model), description="规范评分"),
+        "source": fields.Nested(source_model, description="来源信息"),
+        "apiList": fields.List(fields.Nested(service_list_api_brief), description="仅想定式生成算法含文件名"),
+    },
+)
+
+services_list_response = api.model(
+    "ServicesListResponse",
+    {
+        "status": fields.String(description="响应状态"),
+        "message": fields.String(description="响应消息"),
+        "total": fields.Integer(description="总记录数"),
+        "page": fields.Integer(description="当前页码，未分页时为 null"),
+        "pageSize": fields.Integer(description="每页条数，未分页时为 null"),
+        "services": fields.List(fields.Nested(service_list_item_model), description="微服务列表(精简)"),
+    },
+)
+
+mcp_tool_option_model = api.model(
+    "McpToolOption",
+    {
+        "id": fields.String(description="工具ID"),
+        "name": fields.String(description="工具名称"),
+        "description": fields.String(description="工具描述"),
+        "des": fields.String(description="工具描述(兼容字段)"),
+    },
+)
+
+mcp_service_option_model = api.model(
+    "McpServiceOption",
+    {
+        "id": fields.String(description="服务ID"),
+        "name": fields.String(description="服务名称"),
+        "status": fields.String(description="服务状态"),
+        "des": fields.String(description="服务描述"),
+        "url": fields.String(description="MCP 地址"),
+        "method": fields.String(description="通信方法"),
+        "isFake": fields.Boolean(description="是否为模拟数据"),
+        "tools": fields.List(fields.Nested(mcp_tool_option_model), description="工具列表"),
+    },
+)
+
+mcp_options_response = api.model(
+    "McpOptionsResponse",
+    {
+        "status": fields.String(description="响应状态"),
+        "message": fields.String(description="响应消息"),
+        "total": fields.Integer(description="总记录数"),
+        "services": fields.List(fields.Nested(mcp_service_option_model), description="MCP 服务选项"),
+    },
+)
+
 # 定义简单响应模型
 simple_response = api.model(
     "SimpleResponse",
@@ -375,6 +453,55 @@ class ServiceSearch(Resource):
             return {"status": "error", "message": str(e)}, 500
 
 
+@api.route("/smart-search")
+class ServiceSmartSearch(Resource):
+    @api.doc(
+        "smart_search_services",
+        description="""
+        领域内智能检索：将名称/通用描述/作用/功能/技术要求拆词后，
+        对服务名称、API 描述、来源介绍、行业场景技术编码等现有文本做全表模糊匹配。
+
+        说明：除 name 外，其余 4 个表单字段在 services 表无独立列，仅作为检索词参与匹配。
+        """,
+    )
+    @api.param("domain", "领域 code", required=True)
+    @api.param("name", "名称")
+    @api.param("description", "通用描述")
+    @api.param("role", "作用")
+    @api.param("function", "功能")
+    @api.param("requirement", "技术要求")
+    @api.marshal_with(services_list_response, code=200)
+    @api.response(400, "Invalid input", error_response)
+    def get(self):
+        """智能检索微服务（领域内全表模糊匹配）"""
+        domain = (request.args.get("domain") or "").strip()
+        if not domain:
+            return {"status": "error", "message": "缺少 domain 参数"}, 400
+
+        fields = {
+            "name": request.args.get("name") or "",
+            "description": request.args.get("description") or "",
+            "role": request.args.get("role") or "",
+            "function": request.args.get("function") or "",
+            "requirement": request.args.get("requirement") or "",
+        }
+        if not any(str(value).strip() for value in fields.values()):
+            return {"status": "error", "message": "请至少填写一个检索条件"}, 400
+
+        try:
+            services = service_service.smart_search(domain, **fields)
+            return {
+                "status": "success",
+                "message": "智能检索成功",
+                "total": len(services),
+                "page": None,
+                "pageSize": None,
+                "services": services,
+            }, 200
+        except ServiceServiceError as e:
+            return {"status": "error", "message": str(e)}, 400
+
+
 @api.route("/filter")
 class ServiceFilter(Resource):
     @api.doc("filter_services", description="""
@@ -404,9 +531,11 @@ class ServiceFilter(Resource):
     @api.param("scenario", "场景 (取决于domain，查看对应domain的scenario字典)，多个值用逗号分隔")
     @api.param("technology", "技术 (取决于domain，查看对应domain的technology字典)，多个值用逗号分隔")
     @api.param("status", "服务状态 (not_deployed-未部署, deploying-部署中, pre_release_unrated-预发布(未测评), pre_release_pending-预发布(待平台测评), released-已发布, error-服务异常)，多个值用逗号分隔")
-    @api.marshal_with(services_response, code=200)
+    @api.param("page", "页码，从 1 开始；与 pageSize 同时传入时启用分页")
+    @api.param("pageSize", "每页条数，最大 100；与 page 同时传入时启用分页")
+    @api.marshal_with(services_list_response, code=200)
     def get(self):
-        """筛选微服务"""
+        """筛选微服务（列表精简视图，可选分页）"""
         filters = {}
         valid_filters = ["attribute", "type", "domain", "industry", "scenario", "technology", "status"]
         
@@ -419,17 +548,55 @@ class ServiceFilter(Resource):
                 value_list = [v.strip() for v in value.split(",") if v.strip()]
                 if value_list:
                     filters[key] = value_list
+
+        page_raw = request.args.get("page")
+        page_size_raw = request.args.get("pageSize")
+        page = None
+        page_size = None
+        if page_raw is not None and page_size_raw is not None:
+            try:
+                page = int(page_raw)
+                page_size = int(page_size_raw)
+            except (TypeError, ValueError):
+                return {"status": "error", "message": "page 与 pageSize 必须为整数"}, 400
         
         try:
-            services = service_service.filter_services(**filters)
+            result = service_service.filter_services(
+                page=page, page_size=page_size, **filters
+            )
             return {
                 "status": "success",
                 "message": "筛选微服务成功",
-                "total": len(services),
-                "services": services
+                "total": result["total"],
+                "page": result.get("page"),
+                "pageSize": result.get("pageSize"),
+                "services": result["services"],
             }, 200
         except ServiceServiceError as e:
             return {"status": "error", "message": str(e)}, 500
+
+
+@api.route("/mcp-options")
+class ServiceMcpOptions(Resource):
+    @api.doc("mcp_service_options", description="仿真构建 MCP 服务选择器：返回含 tools 的选项列表，不分页。")
+    @api.param("domain", "领域 code", required=True)
+    @api.marshal_with(mcp_options_response, code=200)
+    @api.response(400, "Invalid input", error_response)
+    def get(self):
+        """获取 MCP 服务选项（含 tools）"""
+        domain = request.args.get("domain")
+        if not domain or not domain.strip():
+            return {"status": "error", "message": "缺少 domain 参数"}, 400
+        try:
+            options = service_service.get_mcp_options(domain.strip())
+            return {
+                "status": "success",
+                "message": "获取 MCP 服务选项成功",
+                "total": len(options),
+                "services": options,
+            }, 200
+        except ServiceServiceError as e:
+            return {"status": "error", "message": str(e)}, 400
 
 
 scenario_generated_upload_parser = api.parser()

--- a/app/models/service/meta_app_config.py
+++ b/app/models/service/meta_app_config.py
@@ -86,9 +86,9 @@ class MetaAppConfig(db.Model):
         if update_time is not None:
             self.update_time = update_time
 
-    def to_api_fields(self):
+    def to_api_fields(self, include_artifact=True):
         """输出合并进 apiList[0] 的元应用字段（camelCase）。"""
-        return {
+        fields = {
             "subtitle": self.subtitle,
             "services": self._services_to_list(self.services),
             "inputName": self.input_name,
@@ -98,7 +98,9 @@ class MetaAppConfig(db.Model):
             "simulationBuildId": self.simulation_build_id,
             "metaAppArtifactId": self.meta_app_artifact_id,
             "metaAppArtifactHash": self.meta_app_artifact_hash,
-            "metaAppArtifact": self.meta_app_artifact,
             "runMode": self.run_mode,
             "runtimeSpec": self.runtime_spec,
         }
+        if include_artifact:
+            fields["metaAppArtifact"] = self.meta_app_artifact
+        return fields

--- a/app/models/service/service.py
+++ b/app/models/service/service.py
@@ -62,7 +62,7 @@ class Service(db.Model):
     def __repr__(self):
         return f"<Service {self.name}>"
 
-    def to_dict(self):
+    def to_dict(self, include_artifact=True):
         """将模型转换为字典"""
         base_dict = {
             "id": self.id,
@@ -90,7 +90,9 @@ class Service(db.Model):
             if len(self.apis) != 1 or self.meta_app_config is None:
                 raise ValueError(f"元应用 {self.id} 配置不完整")
             base_dict["apiList"] = [api.to_dict() for api in self.apis]
-            base_dict["apiList"][0].update(self.meta_app_config.to_api_fields())
+            base_dict["apiList"][0].update(
+                self.meta_app_config.to_api_fields(include_artifact=include_artifact)
+            )
             return base_dict
 
         # 想定式生成算法：仅 apiList，附上下载路径提示（前端拼接 API 根地址）
@@ -136,4 +138,32 @@ class Service(db.Model):
             # 对于REST类型的服务，保持原有的apiList格式
             base_dict["apiList"] = [api.to_dict() for api in self.apis]
         
+        return base_dict
+
+    def to_list_dict(self):
+        """检索列表所需的精简字段（不含 apiList/tools/artifact）。"""
+        base_dict = {
+            "id": self.id,
+            "name": self.name,
+            "attribute": self.attribute,
+            "type": self.type,
+            "domain": self.domain,
+            "industry": self.industry,
+            "scenario": self.scenario,
+            "technology": self.technology,
+            "network": self.network,
+            "port": self.port,
+            "volume": self.volume,
+            "status": self.status,
+            "number": self.number,
+            "deleted": self.deleted,
+            "createTime": self.create_time,
+            "creatorId": self.creator_id,
+            "norm": [norm.to_dict() for norm in self.norms],
+            "source": self.source.to_dict() if self.source else None,
+        }
+        if self.type == "generated_algorithm" and self.apis:
+            response_file_name = self.apis[0].response_file_name
+            if response_file_name:
+                base_dict["apiList"] = [{"responseFileName": response_file_name}]
         return base_dict

--- a/app/repositories/service_repository.py
+++ b/app/repositories/service_repository.py
@@ -35,7 +35,7 @@ class ServiceRepository:
             List[Dict]: 微服务字典列表
         """
         services = self.get_all_services()
-        return [service.to_dict() for service in services]
+        return [service.to_dict(include_artifact=False) for service in services]
     
     def get_service_by_id(self, service_id: str) -> Optional[Service]:
         """
@@ -503,42 +503,63 @@ class ServiceRepository:
         db.session.commit()
         return True
     
-    def filter_services(self, **filters) -> List[Service]:
+    def filter_services(
+        self, page: int = None, page_size: int = None, **filters
+    ) -> tuple:
         """
-        根据条件筛选微服务
-
-        Args:
-            **filters: 筛选条件，可包括:
-                - attribute: 服务属性（支持多个值）
-                - type: 服务类型（支持多个值）
-                - domain: 领域（支持多个值）
-                - industry: 行业（支持多个值）
-                - scenario: 场景（支持多个值）
-                - technology: 技术（支持多个值）
-                - status: 服务状态（支持多个值）
+        根据条件筛选微服务，可选分页。
 
         Returns:
-            List[Service]: 符合条件的微服务对象列表
+            tuple[List[Service], int]: (结果列表, 总记录数)
         """
         query = Service.query.options(
             selectinload(Service.norms),
             joinedload(Service.source),
-            selectinload(Service.apis).selectinload(ServiceApi.parameters),
-            selectinload(Service.apis).selectinload(ServiceApi.tools),
-            joinedload(Service.meta_app_config),
+            selectinload(Service.apis),
         ).filter_by(deleted=0)
 
-        # 应用筛选条件
         valid_filters = ["attribute", "type", "domain", "industry", "scenario", "technology", "status"]
         for key, value in filters.items():
             if key in valid_filters and value is not None:
-                # 支持所有条件都能使用多个值
                 if isinstance(value, list) and len(value) > 0:
                     query = query.filter(getattr(Service, key).in_(value))
                 elif not isinstance(value, list) and value:
                     query = query.filter(getattr(Service, key) == value)
-        
-        return query.all()
+
+        query = query.order_by(Service.create_time.desc())
+        total = query.count()
+
+        if page is not None and page_size is not None:
+            page = max(1, int(page))
+            page_size = max(1, min(int(page_size), 100))
+            services = query.offset((page - 1) * page_size).limit(page_size).all()
+        else:
+            services = query.all()
+
+        return services, total
+
+    def list_mcp_options(self, domain: str) -> List[Service]:
+        """获取指定领域的 MCP 服务（含 tools），供仿真构建选择器使用。"""
+        return (
+            Service.query.options(
+                selectinload(Service.apis).selectinload(ServiceApi.tools),
+            )
+            .filter_by(deleted=0, type="atomic_mcp", domain=domain)
+            .order_by(Service.name.asc())
+            .all()
+        )
+
+    def list_services_in_domain(self, domain: str) -> List[Service]:
+        """获取指定领域下全部未删除服务（含检索所需关联数据）。"""
+        return (
+            Service.query.options(
+                selectinload(Service.norms),
+                joinedload(Service.source),
+                selectinload(Service.apis).selectinload(ServiceApi.tools),
+            )
+            .filter_by(deleted=0, domain=domain)
+            .all()
+        )
     
     def get_service_norms(self, service_id: str) -> List[ServiceNorm]:
         """

--- a/app/services/service_service.py
+++ b/app/services/service_service.py
@@ -3,6 +3,7 @@
 处理微服务相关的业务逻辑
 """
 
+import re
 from typing import Dict, List, Optional, Tuple
 import threading
 import time
@@ -139,7 +140,7 @@ class ServiceService:
         """
         try:
             services = self.service_repository.find_by_attribute(attribute)
-            return [service.to_dict() for service in services]
+            return [service.to_dict(include_artifact=False) for service in services]
         except Exception as e:
             raise ServiceServiceError(f"查询微服务失败: {str(e)}")
 
@@ -278,32 +279,179 @@ class ServiceService:
         """
         try:
             services = self.service_repository.search_by_keyword(keyword)
-            return [service.to_dict() for service in services]
+            return [service.to_dict(include_artifact=False) for service in services]
         except Exception as e:
             raise ServiceServiceError(f"搜索微服务失败: {str(e)}")
 
-    def filter_services(self, **filters) -> List[Dict]:
+    @staticmethod
+    def _normalize_search_text(value) -> str:
+        return str(value or "").strip().lower()
+
+    @classmethod
+    def _extract_smart_search_terms(cls, **fields) -> List[str]:
+        raw = " ".join(str(fields.get(key) or "") for key in ("name", "description", "role", "function", "requirement"))
+        parts = re.split(r"[\s,，;；、。.!！?？/\\|]+", raw)
+        terms = []
+        seen = set()
+        for part in parts:
+            term = cls._normalize_search_text(part)
+            if term and term not in seen:
+                seen.add(term)
+                terms.append(term)
+        return terms
+
+    @classmethod
+    def _build_service_search_text(cls, service) -> Dict[str, str]:
+        api_chunks = []
+        for api in service.apis or []:
+            api_chunks.extend([api.name or "", api.des or ""])
+            for tool in api.tools or []:
+                api_chunks.extend([tool.name or "", tool.description or ""])
+
+        source = service.source
+        source_chunks = []
+        if source:
+            source_chunks = [
+                source.ms_introduce or "",
+                source.company_introduce or "",
+                source.company_name or "",
+            ]
+
+        name = cls._normalize_search_text(service.name)
+        description = cls._normalize_search_text(" ".join(source_chunks + api_chunks))
+        metadata = cls._normalize_search_text(
+            " ".join(
+                [
+                    service.attribute or "",
+                    service.type or "",
+                    service.industry or "",
+                    service.scenario or "",
+                    service.technology or "",
+                    service.status or "",
+                ]
+            )
+        )
+        return {
+            "name": name,
+            "description": description,
+            "metadata": metadata,
+            "all": f"{name} {description} {metadata}",
+        }
+
+    @classmethod
+    def _score_service_for_smart_search(cls, service, terms: List[str]) -> int:
+        text = cls._build_service_search_text(service)
+        if not all(term in text["all"] for term in terms):
+            return 0
+        score = 0
+        for term in terms:
+            if term in text["name"]:
+                score += 8
+            if term in text["description"]:
+                score += 5
+            if term in text["metadata"]:
+                score += 3
+            score += 1
+        return score
+
+    def smart_search(
+        self,
+        domain: str,
+        *,
+        name: str = "",
+        description: str = "",
+        role: str = "",
+        function: str = "",
+        requirement: str = "",
+    ) -> List[Dict]:
         """
-        根据条件筛选微服务
+        领域内智能检索：将 5 个表单字段拆词后，对现有文本字段做全表模糊匹配。
+
+        说明：role / function / requirement 在库中无独立列，仅作为检索词参与匹配。
+        """
+        if not domain or not str(domain).strip():
+            raise ServiceServiceError("domain 不能为空")
+        terms = self._extract_smart_search_terms(
+            name=name,
+            description=description,
+            role=role,
+            function=function,
+            requirement=requirement,
+        )
+        if not terms:
+            raise ServiceServiceError("请至少填写一个检索条件")
+
+        try:
+            services = self.service_repository.list_services_in_domain(str(domain).strip())
+            ranked = []
+            for service in services:
+                score = self._score_service_for_smart_search(service, terms)
+                if score > 0:
+                    ranked.append((score, service))
+            ranked.sort(key=lambda item: (-item[0], -(item[1].create_time or 0)))
+            return [service.to_list_dict() for _, service in ranked]
+        except ServiceServiceError:
+            raise
+        except Exception as e:
+            raise ServiceServiceError(f"智能检索失败: {str(e)}")
+
+    def filter_services(
+        self, page: int = None, page_size: int = None, **filters
+    ) -> Dict:
+        """
+        根据条件筛选微服务（列表视图，可选分页）。
 
         Args:
-            **filters: 筛选条件，可包括:
-                - attribute: 服务属性（支持单个值或多个值列表）
-                - type: 服务类型（支持单个值或多个值列表）
-                - domain: 领域（支持单个值或多个值列表）
-                - industry: 行业（支持单个值或多个值列表）
-                - scenario: 场景（支持单个值或多个值列表）
-                - technology: 技术（支持单个值或多个值列表）
-                - status: 服务状态（支持单个值或多个值列表）
+            page: 页码（从 1 开始）；与 page_size 同时传入时启用分页
+            page_size: 每页条数（最大 100）
+            **filters: 筛选条件
 
         Returns:
-            List[Dict]: 符合条件的微服务列表
+            Dict: services, total, page, pageSize
         """
         try:
-            services = self.service_repository.filter_services(**filters)
-            return [service.to_dict() for service in services]
+            services, total = self.service_repository.filter_services(
+                page=page, page_size=page_size, **filters
+            )
+            return {
+                "services": [service.to_list_dict() for service in services],
+                "total": total,
+                "page": page,
+                "pageSize": page_size,
+            }
         except Exception as e:
             raise ServiceServiceError(f"筛选微服务失败: {str(e)}")
+
+    def get_mcp_options(self, domain: str) -> List[Dict]:
+        """仿真构建 MCP 服务选择器：返回含 tools 的精简选项列表。"""
+        if not domain or not str(domain).strip():
+            raise ServiceServiceError("domain 不能为空")
+        try:
+            services = self.service_repository.list_mcp_options(str(domain).strip())
+            options = []
+            for service in services:
+                api = service.apis[0] if service.apis else None
+                tools = []
+                if api and api.tools:
+                    for tool in api.tools:
+                        item = tool.to_dict()
+                        item["des"] = item.get("description") or ""
+                        tools.append(item)
+                options.append({
+                    "id": service.id,
+                    "name": service.name,
+                    "status": service.status,
+                    "des": (api.des if api else "") or "",
+                    "url": (api.url if api else "") or "",
+                    "method": (api.method if api else "sse") or "sse",
+                    "isFake": bool(api.is_fake) if api else False,
+                    "tools": tools,
+                })
+            return options
+        except ServiceServiceError:
+            raise
+        except Exception as e:
+            raise ServiceServiceError(f"获取 MCP 服务选项失败: {str(e)}")
 
     def deploy_service(self, service_id: str) -> bool:
         """


### PR DESCRIPTION
列表 filter 支持 page/pageSize 并返回 to_list_dict；仿真构建 MCP 选择走专用 mcp-options；智能检索迁至 smart-search 服务端子串匹配。