### PR TITLE
Read generated MCP artifact runtime metadata

### DIFF
--- a/app/services/service_service.py
+++ b/app/services/service_service.py
@@ -21,6 +21,7 @@ from app.extensions import db
 from app.models.service.upgrade_advice import ServiceUpgradeAdvice
 from app.utils.port_utils import allocate_ports, PortAllocationError
 from app.utils.zip_utils import extract_and_find_root, cleanup_directory, ZipProcessError
+from app.utils.mcp_artifact_utils import load_mcp_artifact_metadata
 from app.utils.docker_utils import (
     parse_ports_from_compose,
     modify_compose_ports,
@@ -645,13 +646,18 @@ class ServiceService:
                 
                 # 从环境变量获取部署服务的宿主机URL
                 service_host_url = os.environ.get('SERVICE_HOST_URL', 'https://fdueblab.cn')
+                artifact_metadata = load_mcp_artifact_metadata(project_root)
+                endpoint = artifact_metadata['endpoint']
+                description = artifact_metadata['description'] or (
+                    f'提供{service_data.get("name", "MCP")}功能的MCP服务'
+                )
                 
                 # 生成默认API
                 default_api = {
                     'name': f'{service_data.get("name", "MCP")} Server',
-                    'url': f'{service_host_url}/mcp-proxy/{host_port}/sse',
-                    'method': 'sse',
-                    'des': f'提供{service_data.get("name", "MCP")}功能的MCP服务',
+                    'url': f'{service_host_url.rstrip("/")}/mcp-proxy/{host_port}{endpoint}',
+                    'method': artifact_metadata['method'],
+                    'des': description,
                     'parameterType': 1,
                     'responseType': 1,
                     'isFake': False,
@@ -661,17 +667,7 @@ class ServiceService:
                             'content': '这是一个自动生成的测试消息'
                         }
                     ],
-                    # 为MCP服务添加默认的tools
-                    'tools': [
-                        {
-                            'name': 'healthCheck',
-                            'description': '判断微服务状态是否正常可用'
-                        },
-                        {
-                            'name': 'getServiceInfo',
-                            'description': '获取服务信息和能力描述'
-                        }
-                    ]
+                    'tools': artifact_metadata['tools']
                 }
                 
                 # 更新服务，添加API

--- a/app/utils/mcp_artifact_utils.py
+++ b/app/utils/mcp_artifact_utils.py
@@ -1,0 +1,87 @@
+"""Read runtime metadata from deterministic MCP service artifacts."""
+
+import json
+import re
+from pathlib import Path
+from typing import Dict
+
+
+ARTIFACT_VERSION = "ioeb.mcp-service-artifact/v1"
+DEFAULT_METADATA = {
+    "endpoint": "/sse",
+    "method": "sse",
+    "description": "",
+    "tools": [
+        {
+            "name": "healthCheck",
+            "description": "判断微服务状态是否正常可用",
+        },
+        {
+            "name": "getServiceInfo",
+            "description": "获取服务信息和能力描述",
+        },
+    ],
+}
+_SAFE_ENDPOINT = re.compile(r"^/[A-Za-z0-9._~/-]*$")
+_HTTP_TRANSPORTS = {"http", "streamable-http", "streamable_http"}
+
+
+def _safe_endpoint(value: object) -> str:
+    if not isinstance(value, str) or not _SAFE_ENDPOINT.fullmatch(value):
+        return DEFAULT_METADATA["endpoint"]
+    if "//" in value or ".." in value.split("/"):
+        return DEFAULT_METADATA["endpoint"]
+    return value
+
+
+def load_mcp_artifact_metadata(project_root: str) -> Dict:
+    """Return deploy metadata, retaining legacy SSE defaults when no v1 artifact exists."""
+    metadata = {
+        **DEFAULT_METADATA,
+        "tools": [dict(tool) for tool in DEFAULT_METADATA["tools"]],
+    }
+    manifest_path = Path(project_root) / "ioeb-service.json"
+    if not manifest_path.is_file():
+        return metadata
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return metadata
+    if not isinstance(manifest, dict) or manifest.get("artifactVersion") != ARTIFACT_VERSION:
+        return metadata
+
+    runtime = manifest.get("runtime")
+    runtime = runtime if isinstance(runtime, dict) else {}
+    transport = str(runtime.get("transport", "sse")).strip().lower()
+    endpoint = _safe_endpoint(runtime.get("endpoint"))
+    method = "http" if transport in _HTTP_TRANSPORTS else "sse"
+
+    service = manifest.get("service")
+    service = service if isinstance(service, dict) else {}
+    description = service.get("description")
+    description = description.strip() if isinstance(description, str) else ""
+
+    tool = manifest.get("tool")
+    tools = []
+    if isinstance(tool, dict):
+        name = tool.get("name")
+        tool_description = tool.get("description")
+        if isinstance(name, str) and name.strip():
+            tools.append({
+                "name": name.strip(),
+                "description": (
+                    tool_description.strip()
+                    if isinstance(tool_description, str)
+                    else ""
+                ),
+            })
+
+    metadata.update({
+        "endpoint": endpoint,
+        "method": method,
+        "description": description,
+    })
+    if tools:
+        metadata["tools"] = tools
+    return metadata

--- a/tests/unit/test_mcp_artifact_utils.py
+++ b/tests/unit/test_mcp_artifact_utils.py
@@ -1,0 +1,67 @@
+import json
+
+from app.utils.mcp_artifact_utils import load_mcp_artifact_metadata
+
+
+def test_missing_manifest_uses_legacy_sse_defaults(tmp_path):
+    metadata = load_mcp_artifact_metadata(str(tmp_path))
+
+    assert metadata["endpoint"] == "/sse"
+    assert metadata["method"] == "sse"
+    assert {tool["name"] for tool in metadata["tools"]} == {
+        "healthCheck",
+        "getServiceInfo",
+    }
+
+
+def test_v1_artifact_exposes_streamable_http_tool(tmp_path):
+    manifest = {
+        "artifactVersion": "ioeb.mcp-service-artifact/v1",
+        "service": {
+            "name": "repeat-text",
+            "description": "Repeat text a requested number of times.",
+        },
+        "runtime": {
+            "transport": "streamable-http",
+            "endpoint": "/mcp",
+        },
+        "tool": {
+            "name": "main_process",
+            "description": "Repeat input text.",
+        },
+    }
+    (tmp_path / "ioeb-service.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+
+    metadata = load_mcp_artifact_metadata(str(tmp_path))
+
+    assert metadata == {
+        "endpoint": "/mcp",
+        "method": "http",
+        "description": "Repeat text a requested number of times.",
+        "tools": [{
+            "name": "main_process",
+            "description": "Repeat input text.",
+        }],
+    }
+
+
+def test_invalid_artifact_endpoint_cannot_escape_proxy_path(tmp_path):
+    manifest = {
+        "artifactVersion": "ioeb.mcp-service-artifact/v1",
+        "runtime": {
+            "transport": "streamable-http",
+            "endpoint": "https://attacker.example/mcp",
+        },
+    }
+    (tmp_path / "ioeb-service.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+
+    metadata = load_mcp_artifact_metadata(str(tmp_path))
+
+    assert metadata["endpoint"] == "/sse"
+    assert metadata["method"] == "http"


### PR DESCRIPTION
## What changed

- read `ioeb-service.json` from generated MCP artifacts during the existing upload/deploy flow
- register the generated `/mcp` endpoint and HTTP transport instead of assuming legacy `/sse`
- expose the generated `main_process` Tool and service description in catalog metadata
- retain the legacy SSE defaults for artifacts without the v1 manifest

## Why

The deterministic packager generates Streamable HTTP MCP services. The backend previously hard-coded `/sse`, so a successfully deployed generated service would be registered with an unusable URL and transport.

## Impact

This is a compatibility change inside the current deployment flow. It does not refactor task handling, Docker Compose deployment, or the frontend.

## Validation

- `13 passed` in the full backend test suite
- `3 passed` for artifact metadata compatibility and endpoint safety
- cross-repository handoff verified: container port `8000` was rewritten to an allocated host port and catalog metadata resolved to `/mcp`, `http`, and `main_process`

No environment was updated manually. Merging this PR should use the repository's existing GitHub Actions deployment workflow.
