### PR TITLE
Fix services volume permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,6 +51,20 @@ jobs:
           pytest tests/unit --cov=app --cov-report=xml
           pytest tests/integration
 
+      - name: Verify services bind mount permissions
+        run: |
+          docker build -t ioeb-backend:permission-test .
+          services_dir="${RUNNER_TEMP}/ioeb-services-permission-test"
+          sudo mkdir -p "${services_dir}"
+          sudo chown root:root "${services_dir}"
+          sudo chmod 0755 "${services_dir}"
+          docker run --rm \
+            -e SERVICES_BASE_PATH=/app/data/services \
+            -v "${services_dir}:/app/data/services" \
+            ioeb-backend:permission-test \
+            python -c "import os; from pathlib import Path; assert os.getuid() == 1000; Path('/app/data/services/probe').mkdir()"
+          test -d "${services_dir}/probe"
+
   build:
     name: Build & Push Image
     needs: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,19 +41,20 @@ COPY . .
 # 定义UID和GID（可通过构建参数覆盖）
 ARG APP_USER_UID=1000
 ARG APP_USER_GID=1000
-ARG DOCKER_GID=998
 
 # 创建非root用户（明确指定UID）
 RUN groupadd -g ${APP_USER_GID} appuser \
     && useradd -m -u ${APP_USER_UID} -g appuser -s /bin/bash appuser
 
-# 创建docker组并将appuser添加到docker组
-# GID必须与宿主机的docker组GID匹配（默认998）
-RUN groupadd -g ${DOCKER_GID} docker || true \
-    && usermod -aG docker appuser
-
 RUN chown -R appuser:appuser /app
-USER appuser
+
+# 入口脚本以root初始化宿主机挂载目录，然后立即降权为appuser。
+# 单独复制到/usr/local/bin，避免root入口脚本可被应用用户修改。
+COPY container_entrypoint.py /usr/local/bin/ioeb-backend-entrypoint
+RUN chown root:root /usr/local/bin/ioeb-backend-entrypoint \
+    && chmod 0755 /usr/local/bin/ioeb-backend-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/ioeb-backend-entrypoint"]
 
 # 暴露端口
 EXPOSE 5000

--- a/container_entrypoint.py
+++ b/container_entrypoint.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Prepare mounted runtime paths and launch the backend as the application user."""
+
+from __future__ import annotations
+
+import grp
+import os
+import pwd
+import stat
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+DEFAULT_SERVICES_PATH = "/app/data/services"
+DEFAULT_DOCKER_SOCKET = "/var/run/docker.sock"
+DEFAULT_APP_USER = "appuser"
+
+
+def prepare_services_directory(path: Path, uid: int, gid: int) -> None:
+    """Create the services directory and make its root writable by appuser."""
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        os.chown(path, uid, gid)
+    except OSError as exc:
+        raise RuntimeError(
+            f"cannot initialize services directory {path}: {exc}"
+        ) from exc
+
+
+def supplementary_group_ids(
+    username: str,
+    primary_gid: int,
+    docker_socket: Path,
+) -> list[int]:
+    """Return app groups plus the mounted Docker socket's actual group id."""
+    group_ids = {primary_gid}
+    group_ids.update(
+        group.gr_gid for group in grp.getgrall() if username in group.gr_mem
+    )
+
+    try:
+        socket_stat = docker_socket.stat()
+    except FileNotFoundError:
+        pass
+    else:
+        if stat.S_ISSOCK(socket_stat.st_mode):
+            group_ids.add(socket_stat.st_gid)
+
+    return sorted(group_ids)
+
+
+def drop_privileges_and_exec(
+    command: Sequence[str],
+    username: str = DEFAULT_APP_USER,
+) -> None:
+    """Drop root privileges while retaining access to the mounted Docker socket."""
+    if not command:
+        raise RuntimeError("no command was provided to the container entrypoint")
+
+    user = pwd.getpwnam(username)
+    services_path = Path(os.environ.get("SERVICES_BASE_PATH", DEFAULT_SERVICES_PATH))
+
+    if os.geteuid() == 0:
+        prepare_services_directory(services_path, user.pw_uid, user.pw_gid)
+        groups = supplementary_group_ids(
+            username,
+            user.pw_gid,
+            Path(DEFAULT_DOCKER_SOCKET),
+        )
+        os.setgroups(groups)
+        os.setgid(user.pw_gid)
+        os.setuid(user.pw_uid)
+    else:
+        services_path.mkdir(parents=True, exist_ok=True)
+        if not os.access(services_path, os.W_OK | os.X_OK):
+            raise RuntimeError(
+                f"services directory is not writable by uid {os.geteuid()}: "
+                f"{services_path}"
+            )
+
+    os.execvp(command[0], list(command))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    command = list(sys.argv[1:] if argv is None else argv)
+    try:
+        drop_privileges_and_exec(command)
+    except (KeyError, OSError, RuntimeError) as exc:
+        print(f"Container startup failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_container_entrypoint.py
+++ b/tests/unit/test_container_entrypoint.py
@@ -1,0 +1,90 @@
+import grp
+import os
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import container_entrypoint
+
+
+def test_prepare_services_directory_creates_and_chowns_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    services_path = tmp_path / "nested" / "services"
+    chown_calls = []
+    monkeypatch.setattr(
+        os,
+        "chown",
+        lambda path, uid, gid: chown_calls.append((path, uid, gid)),
+    )
+
+    container_entrypoint.prepare_services_directory(services_path, 1000, 1000)
+
+    assert services_path.is_dir()
+    assert chown_calls == [(services_path, 1000, 1000)]
+
+
+def test_supplementary_groups_include_socket_group(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    socket_gid = 4321
+    monkeypatch.setattr(
+        Path,
+        "stat",
+        lambda _: SimpleNamespace(st_mode=stat.S_IFSOCK, st_gid=socket_gid),
+    )
+    monkeypatch.setattr(
+        grp,
+        "getgrall",
+        lambda: [SimpleNamespace(gr_gid=1234, gr_mem=["appuser"])],
+    )
+
+    group_ids = container_entrypoint.supplementary_group_ids(
+        "appuser", 1000, Path("/var/run/docker.sock")
+    )
+
+    assert set(group_ids) == {1000, 1234, socket_gid}
+
+
+def test_drop_privileges_before_exec(monkeypatch: pytest.MonkeyPatch):
+    calls = []
+    user = SimpleNamespace(pw_uid=1000, pw_gid=1000)
+    monkeypatch.setattr(container_entrypoint.pwd, "getpwnam", lambda _: user)
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        container_entrypoint,
+        "prepare_services_directory",
+        lambda path, uid, gid: calls.append(("prepare", path, uid, gid)),
+    )
+    monkeypatch.setattr(
+        container_entrypoint,
+        "supplementary_group_ids",
+        lambda username, gid, socket_path: [998, 1000],
+    )
+    monkeypatch.setattr(
+        os,
+        "setgroups",
+        lambda groups: calls.append(("groups", groups)),
+    )
+    monkeypatch.setattr(os, "setgid", lambda gid: calls.append(("gid", gid)))
+    monkeypatch.setattr(os, "setuid", lambda uid: calls.append(("uid", uid)))
+
+    def fake_execvp(executable, command):
+        calls.append(("exec", executable, command))
+        raise RuntimeError("exec reached")
+
+    monkeypatch.setattr(os, "execvp", fake_execvp)
+
+    with pytest.raises(RuntimeError, match="exec reached"):
+        container_entrypoint.drop_privileges_and_exec(["python", "-V"])
+
+    assert [call[0] for call in calls] == [
+        "prepare",
+        "groups",
+        "gid",
+        "uid",
+        "exec",
+    ]


### PR DESCRIPTION
## What changed

- initialize the bind-mounted services directory before the backend starts
- discover the mounted Docker socket's actual group ID at runtime
- immediately drop privileges and run Gunicorn as `appuser`
- add unit coverage and a Docker bind-mount regression test to CI

## Root cause

The image changed `/app/data/services` ownership during build, but the runtime bind mount `/data/ioeb_services:/app/data/services` replaced that directory. When the host directory was owned by root, the non-root backend process could not create a per-service directory, so `/api/services/upload` returned HTTP 400 with `Permission denied`.

## Impact

Uploads can create their deployment directory on a fresh or root-owned host bind mount without running the backend application as root. Docker socket access also no longer depends on a hard-coded host group ID.

## Validation

- 12 unit tests passed
- 4 integration tests passed
- Flake8 critical checks and Black formatting passed
- built and ran the image against a real `root:root 0755` bind mount; UID 1000 created the service directory successfully
- verified the application process retained the mounted Docker socket's runtime GID
