### PR TITLE
fix: verify MCP readiness before deploy success

### DIFF
--- a/app/services/service_service.py
+++ b/app/services/service_service.py
@@ -3,6 +3,7 @@
 处理微服务相关的业务逻辑
 """
 
+import json
 import re
 from typing import Dict, List, Optional, Tuple
 import threading
@@ -53,6 +54,56 @@ class ServiceService:
     def _is_deploy_still_active(self, service_id: str) -> bool:
         service = self.service_repository.get_service_by_id(service_id)
         return service is not None and service.status == "deploying"
+
+    @staticmethod
+    def _load_mcp_artifact_metadata(project_root: str) -> Dict:
+        """读取 Agent 产物中的传输端点和真实工具清单。"""
+        metadata = {
+            "endpoint": "/sse",
+            "tools": []
+        }
+
+        manifest_path = os.path.join(project_root, "ioeb-service.json")
+        try:
+            with open(manifest_path, "r", encoding="utf-8") as manifest_file:
+                manifest = json.load(manifest_file)
+            endpoint = manifest.get("endpoint")
+            if (
+                isinstance(endpoint, str)
+                and endpoint.startswith("/")
+                and ".." not in endpoint
+                and "?" not in endpoint
+                and "#" not in endpoint
+            ):
+                metadata["endpoint"] = endpoint
+        except (OSError, ValueError, TypeError):
+            pass
+
+        plan_path = os.path.join(project_root, "packaging_plan.json")
+        try:
+            with open(plan_path, "r", encoding="utf-8") as plan_file:
+                plan = json.load(plan_file)
+            if plan.get("schemaVersion") != "ioeb.agentic-mcp-plan/v1":
+                return metadata
+
+            tools = []
+            seen_names = set()
+            for logical_service in plan.get("services", []):
+                for tool in logical_service.get("tools", []):
+                    name = tool.get("name")
+                    if not isinstance(name, str) or not name or name in seen_names:
+                        continue
+                    description = tool.get("description", "")
+                    tools.append({
+                        "name": name,
+                        "description": description if isinstance(description, str) else ""
+                    })
+                    seen_names.add(name)
+            metadata["tools"] = tools
+        except (OSError, ValueError, TypeError, AttributeError):
+            pass
+
+        return metadata
 
     def get_all_services(self) -> List[Dict]:
         """
@@ -637,19 +688,22 @@ class ServiceService:
             
             self.service_repository.update_service(service_id, update_data)
             
-            # 10. 如果用户没有提供apiList，自动生成默认的MCP API
-            if not service_data.get('apiList'):
-                # 从port_mappings中提取宿主机端口（第一个端口）
-                # port_mappings格式: ["27000:8000"]
-                host_port = port_mappings[0].split(':')[0]
-                
+            # 10. 为MCP产物登记真实端点和Agent规划出的工具清单
+            host_port = port_mappings[0].split(':')[0]
+            artifact_metadata = self._load_mcp_artifact_metadata(project_root)
+            mcp_endpoint = artifact_metadata["endpoint"]
+            is_mcp_service = service_data.get('type') == 'atomic_mcp'
+
+            if is_mcp_service and not service_data.get('apiList'):
                 # 从环境变量获取部署服务的宿主机URL
-                service_host_url = os.environ.get('SERVICE_HOST_URL', 'https://fdueblab.cn')
+                service_host_url = os.environ.get(
+                    'SERVICE_HOST_URL',
+                    'https://fdueblab.cn'
+                ).rstrip('/')
                 
-                # 生成默认API
-                default_api = {
+                mcp_api = {
                     'name': f'{service_data.get("name", "MCP")} Server',
-                    'url': f'{service_host_url}/mcp-proxy/{host_port}/sse',
+                    'url': f'{service_host_url}/mcp-proxy/{host_port}{mcp_endpoint}',
                     'method': 'sse',
                     'des': f'提供{service_data.get("name", "MCP")}功能的MCP服务',
                     'parameterType': 1,
@@ -661,24 +715,17 @@ class ServiceService:
                             'content': '这是一个自动生成的测试消息'
                         }
                     ],
-                    # 为MCP服务添加默认的tools
-                    'tools': [
-                        {
-                            'name': 'healthCheck',
-                            'description': '判断微服务状态是否正常可用'
-                        },
-                        {
-                            'name': 'getServiceInfo',
-                            'description': '获取服务信息和能力描述'
-                        }
-                    ]
+                    'tools': artifact_metadata["tools"]
                 }
                 
                 # 更新服务，添加API
                 self.service_repository.update_service_with_relations(service_id, {
-                    'apiList': [default_api]
+                    'apiList': [mcp_api]
                 })
-                print(f"服务 {service_id} 已自动添加默认API: {default_api['url']}")
+                print(
+                    f"服务 {service_id} 已登记MCP API: {mcp_api['url']}，"
+                    f"工具数: {len(mcp_api['tools'])}"
+                )
             
             # 11. 启动异步部署任务
             app = current_app._get_current_object()
@@ -690,7 +737,19 @@ class ServiceService:
                         print(f"开始部署服务 {service_id}")
                         
                         # 执行docker-compose部署
-                        success, message = docker_deploy(project_root, service_id, timeout=600)
+                        readiness_url = None
+                        if is_mcp_service:
+                            readiness_url = (
+                                f"http://127.0.0.1:{host_port}{mcp_endpoint}"
+                            )
+
+                        success, message = docker_deploy(
+                            project_root,
+                            service_id,
+                            timeout=600,
+                            readiness_url=readiness_url,
+                            readiness_timeout=120
+                        )
                         
                         if not self._is_deploy_still_active(service_id):
                             return

--- a/app/utils/docker_utils.py
+++ b/app/utils/docker_utils.py
@@ -5,7 +5,9 @@ Docker部署工具模块
 
 import os
 import subprocess
+import time
 import yaml
+import requests
 from typing import List, Tuple
 
 
@@ -163,7 +165,98 @@ def modify_compose_ports(compose_file_path: str, allocated_ports: List[int]) -> 
         raise DockerDeployError(f"修改docker-compose.yml失败: {str(e)}")
 
 
-def deploy_service(project_root: str, service_id: str, timeout: int = 600) -> Tuple[bool, str]:
+def wait_for_mcp_sse_ready(
+    readiness_url: str,
+    timeout: int = 120,
+    interval: float = 2.0
+) -> Tuple[bool, str]:
+    """等待 MCP SSE 端点真正开始提供事件流。"""
+    deadline = time.monotonic() + timeout
+    last_error = "尚未收到有效响应"
+
+    while True:
+        try:
+            response = requests.get(
+                readiness_url,
+                stream=True,
+                timeout=(3, 5)
+            )
+            try:
+                content_type = response.headers.get('Content-Type', '').lower()
+                if response.status_code == 200 and 'text/event-stream' in content_type:
+                    message_endpoint = _read_mcp_message_endpoint(response)
+                    if message_endpoint:
+                        return True, (
+                            f"MCP SSE端点已就绪: {readiness_url}，"
+                            f"消息端点: {message_endpoint}"
+                        )
+                    last_error = "SSE连接成功，但未收到MCP endpoint事件"
+                else:
+                    last_error = (
+                        f"HTTP {response.status_code}, "
+                        f"Content-Type={content_type or 'unknown'}"
+                    )
+            finally:
+                response.close()
+        except requests.RequestException as exc:
+            last_error = str(exc)
+
+        if time.monotonic() >= deadline:
+            return False, f"等待MCP SSE端点超时（{timeout}秒）: {last_error}"
+        time.sleep(interval)
+
+
+def _read_mcp_message_endpoint(response) -> str:
+    """读取 FastMCP 建连后发送的首个 ``endpoint`` SSE 事件。"""
+    event_name = ""
+    data_lines = []
+    for line in response.iter_lines(chunk_size=1, decode_unicode=True):
+        if isinstance(line, bytes):
+            line = line.decode("utf-8", errors="replace")
+        if line == "":
+            if event_name == "endpoint" and data_lines:
+                endpoint = "\n".join(data_lines).strip()
+                if endpoint.startswith("/"):
+                    return endpoint
+            event_name = ""
+            data_lines = []
+            continue
+        if line.startswith("event:"):
+            event_name = line[6:].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+    return ""
+
+
+def _get_compose_logs(
+    compose_file: str,
+    project_name: str,
+    project_root: str
+) -> str:
+    """读取有限长度的容器日志，便于定位启动失败原因。"""
+    try:
+        result = subprocess.run(
+            [
+                'docker-compose', '-f', compose_file, '-p', project_name,
+                'logs', '--no-color', '--tail', '100'
+            ],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        return (result.stdout or result.stderr or '').strip()
+    except Exception as exc:
+        return f"读取容器日志失败: {str(exc)}"
+
+
+def deploy_service(
+    project_root: str,
+    service_id: str,
+    timeout: int = 600,
+    readiness_url: str = None,
+    readiness_timeout: int = 120
+) -> Tuple[bool, str]:
     """
     使用docker-compose部署服务
     
@@ -171,6 +264,8 @@ def deploy_service(project_root: str, service_id: str, timeout: int = 600) -> Tu
         project_root: 项目根目录路径（包含docker-compose.yml）
         service_id: 服务ID
         timeout: 超时时间（秒），默认600秒（10分钟）
+        readiness_url: 可选的MCP SSE就绪检查地址
+        readiness_timeout: MCP SSE就绪检查超时时间（秒）
         
     Returns:
         Tuple[bool, str]: (是否成功, 错误信息或成功信息)
@@ -197,7 +292,6 @@ def deploy_service(project_root: str, service_id: str, timeout: int = 600) -> Tu
             return False, f"docker-compose up 失败: {error_msg}"
         
         # 等待容器启动
-        import time
         time.sleep(5)
         
         # 检查容器状态
@@ -209,11 +303,23 @@ def deploy_service(project_root: str, service_id: str, timeout: int = 600) -> Tu
             timeout=30
         )
         
-        # 简单判断：输出中包含 "Up" 表示成功
+        # 容器进程必须先处于运行状态
         if check_result.returncode == 0 and 'Up' in check_result.stdout:
-            return True, f"服务部署成功，容器运行中"
-        
-        return False, f"容器启动失败，状态: {check_result.stdout}"
+            if readiness_url:
+                ready, message = wait_for_mcp_sse_ready(
+                    readiness_url,
+                    timeout=readiness_timeout
+                )
+                if not ready:
+                    logs = _get_compose_logs(compose_file, project_name, project_root)
+                    if logs:
+                        message = f"{message}\n容器日志:\n{logs}"
+                    return False, message
+                return True, f"服务部署成功，容器运行中；{message}"
+            return True, "服务部署成功，容器运行中"
+
+        logs = _get_compose_logs(compose_file, project_name, project_root)
+        return False, f"容器启动失败，状态: {check_result.stdout}\n容器日志:\n{logs}"
         
     except subprocess.TimeoutExpired:
         return False, f"docker-compose执行超时（{timeout}秒）"
@@ -256,4 +362,3 @@ def stop_and_remove_service(project_root: str, service_id: str) -> bool:
     except Exception as e:
         print(f"停止容器失败: {str(e)}")
         return False
-

--- a/tests/unit/test_docker_utils.py
+++ b/tests/unit/test_docker_utils.py
@@ -1,0 +1,92 @@
+import requests
+
+from app.utils import docker_utils
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        status_code=200,
+        content_type="text/event-stream",
+        lines=None
+    ):
+        self.status_code = status_code
+        self.headers = {"Content-Type": content_type}
+        self.closed = False
+        self.lines = lines or [
+            "event: endpoint",
+            "data: /messages/?session_id=test-session",
+            ""
+        ]
+
+    def iter_lines(self, **kwargs):
+        return iter(self.lines)
+
+    def close(self):
+        self.closed = True
+
+
+def test_wait_for_mcp_sse_ready_accepts_event_stream(monkeypatch):
+    response = FakeResponse()
+    monkeypatch.setattr(docker_utils.requests, "get", lambda *args, **kwargs: response)
+
+    ready, message = docker_utils.wait_for_mcp_sse_ready(
+        "http://127.0.0.1:27001/sse",
+        timeout=1
+    )
+
+    assert ready is True
+    assert "MCP SSE端点已就绪" in message
+    assert response.closed is True
+
+
+def test_wait_for_mcp_sse_ready_reports_timeout(monkeypatch):
+    times = iter([0.0, 2.0])
+    monkeypatch.setattr(docker_utils.time, "monotonic", lambda: next(times))
+
+    def fail_request(*args, **kwargs):
+        raise requests.ConnectionError("connection refused")
+
+    monkeypatch.setattr(docker_utils.requests, "get", fail_request)
+
+    ready, message = docker_utils.wait_for_mcp_sse_ready(
+        "http://127.0.0.1:27001/sse",
+        timeout=1,
+        interval=0
+    )
+
+    assert ready is False
+    assert "等待MCP SSE端点超时" in message
+    assert "connection refused" in message
+
+
+def test_wait_for_mcp_sse_ready_rejects_plain_http_response(monkeypatch):
+    times = iter([0.0, 2.0])
+    response = FakeResponse(content_type="application/json")
+    monkeypatch.setattr(docker_utils.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(docker_utils.requests, "get", lambda *args, **kwargs: response)
+
+    ready, message = docker_utils.wait_for_mcp_sse_ready(
+        "http://127.0.0.1:27001/sse",
+        timeout=1,
+        interval=0
+    )
+
+    assert ready is False
+    assert "Content-Type=application/json" in message
+
+
+def test_wait_for_mcp_sse_ready_requires_endpoint_event(monkeypatch):
+    times = iter([0.0, 2.0])
+    response = FakeResponse(lines=["event: ping", "data: ok", ""])
+    monkeypatch.setattr(docker_utils.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(docker_utils.requests, "get", lambda *args, **kwargs: response)
+
+    ready, message = docker_utils.wait_for_mcp_sse_ready(
+        "http://127.0.0.1:27001/sse",
+        timeout=1,
+        interval=0
+    )
+
+    assert ready is False
+    assert "未收到MCP endpoint事件" in message

--- a/tests/unit/test_service_artifact_metadata.py
+++ b/tests/unit/test_service_artifact_metadata.py
@@ -1,0 +1,51 @@
+import json
+
+from app.services.service_service import ServiceService
+
+
+def test_load_mcp_artifact_metadata_reads_agent_plan(tmp_path):
+    (tmp_path / "ioeb-service.json").write_text(
+        json.dumps({"endpoint": "/custom-sse"}),
+        encoding="utf-8"
+    )
+    (tmp_path / "packaging_plan.json").write_text(
+        json.dumps({
+            "schemaVersion": "ioeb.agentic-mcp-plan/v1",
+            "services": [
+                {
+                    "tools": [
+                        {"name": "predict_risk", "description": "预测风险"},
+                        {"name": "explain_risk", "description": "解释风险"}
+                    ]
+                },
+                {
+                    "tools": [
+                        {"name": "predict_risk", "description": "重复项"},
+                        {"name": "batch_score", "description": "批量评分"}
+                    ]
+                }
+            ]
+        }),
+        encoding="utf-8"
+    )
+
+    metadata = ServiceService._load_mcp_artifact_metadata(str(tmp_path))
+
+    assert metadata["endpoint"] == "/custom-sse"
+    assert [tool["name"] for tool in metadata["tools"]] == [
+        "predict_risk",
+        "explain_risk",
+        "batch_score"
+    ]
+
+
+def test_load_mcp_artifact_metadata_has_safe_fallbacks(tmp_path):
+    (tmp_path / "ioeb-service.json").write_text(
+        json.dumps({"endpoint": "/../internal?token=secret"}),
+        encoding="utf-8"
+    )
+    (tmp_path / "packaging_plan.json").write_text("not-json", encoding="utf-8")
+
+    metadata = ServiceService._load_mcp_artifact_metadata(str(tmp_path))
+
+    assert metadata == {"endpoint": "/sse", "tools": []}


### PR DESCRIPTION
## What changed
- deployment success now requires a live MCP SSE endpoint event, not only a Docker Up status
- deployment failures include the last 100 container log lines
- uploaded Agent artifacts register the real tool list from packaging_plan.json
- removed synthetic healthCheck/getServiceInfo tool registration

## Why
The asynchronous upload endpoint returned immediately, while the background Docker build could still fail. The backend also treated a running container process as a usable MCP server.

## Validation
- full backend test suite: 18 passed
- new readiness and artifact metadata unit tests: 6 passed