### PR TITLE
fix: handle idle MCP SSE readiness streams

### DIFF
--- a/app/utils/docker_utils.py
+++ b/app/utils/docker_utils.py
@@ -13,6 +13,10 @@ import requests
 from typing import List, Tuple, Union
 
 
+MCP_SSE_CONNECT_TIMEOUT = 3
+MCP_SSE_READ_TIMEOUT = 5
+
+
 class DockerDeployError(Exception):
     """Docker部署错误"""
     pass
@@ -259,12 +263,23 @@ def wait_for_mcp_sse_ready(
                 response = requests.get(
                     candidate_url,
                     stream=True,
-                    timeout=(3, 5)
+                    timeout=(MCP_SSE_CONNECT_TIMEOUT, MCP_SSE_READ_TIMEOUT)
                 )
                 try:
                     content_type = response.headers.get('Content-Type', '').lower()
                     if response.status_code == 200 and 'text/event-stream' in content_type:
-                        message_endpoint = _read_mcp_message_endpoint(response)
+                        try:
+                            message_endpoint = _read_mcp_message_endpoint(response)
+                        except requests.RequestException as exc:
+                            if _is_idle_sse_stream(response, exc):
+                                return True, (
+                                    f"MCP SSE端点已就绪: {candidate_url}，"
+                                    "HTTP事件流保持连接（首个endpoint事件未在探测窗口内到达）"
+                                )
+                            last_errors[candidate_url] = (
+                                f"SSE连接读取失败: {str(exc)}"
+                            )
+                            continue
                         if message_endpoint:
                             return True, (
                                 f"MCP SSE端点已就绪: {candidate_url}，"
@@ -312,6 +327,24 @@ def _read_mcp_message_endpoint(response) -> str:
         elif line.startswith("data:"):
             data_lines.append(line[5:].lstrip())
     return ""
+
+
+def _is_idle_sse_stream(response, exc: requests.RequestException) -> bool:
+    """识别已建立但暂时没有事件数据的真实 SSE 长连接。
+
+    ``requests`` 在 ``iter_lines`` 阶段会把 urllib3 的读取超时包装成
+    ``ConnectionError``。只有响应具备 FastMCP/SSE 的防缓存长连接头时，
+    才把这种读取超时视为服务已经就绪；连接重置等其他异常仍然失败。
+    """
+    if 'read timed out' not in str(exc).lower():
+        return False
+
+    cache_control = response.headers.get('Cache-Control', '').lower()
+    buffering = response.headers.get('X-Accel-Buffering', '').lower()
+    connection = response.headers.get('Connection', '').lower()
+    prevents_cache = 'no-store' in cache_control or 'no-cache' in cache_control
+    keeps_connection = buffering == 'no' or 'keep-alive' in connection
+    return prevents_cache and keeps_connection
 
 
 def _get_compose_logs(

--- a/tests/unit/test_docker_utils.py
+++ b/tests/unit/test_docker_utils.py
@@ -1,3 +1,7 @@
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
 import requests
 
 from app.utils import docker_utils
@@ -173,3 +177,86 @@ def test_wait_for_mcp_sse_ready_requires_endpoint_event(monkeypatch):
 
     assert ready is False
     assert "未收到MCP endpoint事件" in message
+
+
+def test_wait_for_mcp_sse_ready_accepts_real_idle_event_stream(monkeypatch):
+    class IdleSseHandler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Connection", "keep-alive")
+            self.send_header("X-Accel-Buffering", "no")
+            self.end_headers()
+            self.wfile.flush()
+            time.sleep(0.2)
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), IdleSseHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setattr(docker_utils, "MCP_SSE_READ_TIMEOUT", 0.05)
+
+    try:
+        ready, message = docker_utils.wait_for_mcp_sse_ready(
+            f"http://127.0.0.1:{server.server_port}/sse",
+            timeout=1,
+            interval=0,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+    assert ready is True
+    assert "HTTP事件流保持连接" in message
+
+
+def test_wait_for_mcp_sse_ready_rejects_non_timeout_stream_error(monkeypatch):
+    times = iter([0.0, 2.0])
+    response = FakeResponse()
+    response.headers.update({
+        "Cache-Control": "no-store",
+        "X-Accel-Buffering": "no",
+    })
+
+    def broken_stream(**kwargs):
+        raise requests.ConnectionError("connection reset by peer")
+
+    response.iter_lines = broken_stream
+    monkeypatch.setattr(docker_utils.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(docker_utils.requests, "get", lambda *args, **kwargs: response)
+
+    ready, message = docker_utils.wait_for_mcp_sse_ready(
+        "http://127.0.0.1:27001/sse",
+        timeout=1,
+        interval=0,
+    )
+
+    assert ready is False
+    assert "connection reset by peer" in message
+
+
+def test_wait_for_mcp_sse_ready_rejects_idle_stream_without_keepalive_headers(monkeypatch):
+    times = iter([0.0, 2.0])
+    response = FakeResponse()
+
+    def idle_stream(**kwargs):
+        raise requests.ConnectionError("HTTPConnectionPool: Read timed out.")
+
+    response.iter_lines = idle_stream
+    monkeypatch.setattr(docker_utils.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(docker_utils.requests, "get", lambda *args, **kwargs: response)
+
+    ready, message = docker_utils.wait_for_mcp_sse_ready(
+        "http://127.0.0.1:27001/sse",
+        timeout=1,
+        interval=0,
+    )
+
+    assert ready is False
+    assert "Read timed out" in message


### PR DESCRIPTION
## What changed

- recognize a valid idle MCP SSE connection when the Docker gateway delays the first `endpoint` event beyond the probe read window
- require HTTP 200, `text/event-stream`, cache prevention, and long-connection headers before using the timeout fallback
- continue rejecting connection resets, ordinary HTTP responses, finite streams without an MCP endpoint event, and idle responses without SSE keepalive headers
- add a real threaded HTTP SSE server regression test in addition to failure-path tests

## Root cause

The generated MCP container started successfully and `/sse` returned HTTP 200, but the backend readiness probe waited for the first SSE `endpoint` event through the Docker gateway. The event body was not delivered within the five-second read window, so `requests` raised a wrapped read timeout. Repeated probes exhausted the 120-second deployment deadline and incorrectly cleaned up a healthy container.

## Validation

- `26 passed` in the complete backend test suite
- the regression test opens a real HTTP event-stream connection that intentionally stays idle beyond the read timeout
- wrong content type, missing keepalive headers, missing endpoint event on a completed stream, and connection reset cases remain failures
- no staging or production environment was modified manually
